### PR TITLE
Fixes interpretation of background=-1 while rotating an image.

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -826,9 +826,15 @@ class Image implements LoggerAwareInterface
 		// Create the new truecolor image handle.
 		$handle = imagecreatetruecolor($this->getWidth(), $this->getHeight());
 
-		// Allow transparency for the new image handle.
-		imagealphablending($handle, false);
-		imagesavealpha($handle, true);
+		// Make background transparent if no external background color is provided.
+		if ($background == -1)
+		{
+			// Allow transparency for the new image handle.
+			imagealphablending($handle, false);
+			imagesavealpha($handle, true);
+
+			$background = imagecolorallocatealpha($handle , 0, 0, 0, 127);
+		}
 
 		// Copy the image
 		imagecopy($handle, $this->handle, 0, 0, 0, 0, $this->getWidth(), $this->getHeight());


### PR DESCRIPTION
https://github.com/joomla-framework/image/blob/master/Tests/ImageTest.php#L773 test is failing when executed locally.

`$image->handle` is false after rotation. I found out that when background=-1 is set for rotation then `imagerotate($handle, $angle, $background);` returns false.

I assumed that if background=-1 is to make background transparent then we have an issue. This PR solves this issue.

<edit>Test fails only on php 5.x</edit>
