### PR TITLE
Use `@link` over `@see` and fix invalid return doc block

### DIFF
--- a/Tests/stubs/ImageInspector.php
+++ b/Tests/stubs/ImageInspector.php
@@ -48,7 +48,7 @@ class ImageInspector extends Image
 	 * @param   string  $name   The name of the property.
 	 * @param   mixed   $value  The value of the property.
 	 *
-	 * @return  void.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */

--- a/src/Image.php
+++ b/src/Image.php
@@ -945,7 +945,7 @@ class Image implements LoggerAwareInterface
 	 * @return  Image
 	 *
 	 * @since   1.3.0
-	 * @see     https://secure.php.net/manual/en/image.examples-watermark.php
+	 * @link    https://secure.php.net/manual/en/image.examples-watermark.php
 	 */
 	public function watermark(Image $watermark, $transparency = 50, $bottomMargin = 0, $rightMargin = 0)
 	{
@@ -975,7 +975,7 @@ class Image implements LoggerAwareInterface
 	 *
 	 * @return  boolean
 	 *
-	 * @see     http://www.php.net/manual/image.constants.php
+	 * @link    http://www.php.net/manual/image.constants.php
 	 * @since   1.0
 	 * @throws  \LogicException
 	 */


### PR DESCRIPTION
### Summary of Changes

Use `@link` over `@see` and fix invalid return doc block

### Testing Instructions

Review

### Documentation Changes Required

None