### PR TITLE
CS: Using constants for crop types

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -336,13 +336,13 @@ class Image implements LoggerAwareInterface
 
 				switch ($creationMethod)
 				{
-					// Case for self::CROP
-					case 4:
+					// Crop
+					case self::CROP:
 						$thumb = $this->crop($thumbWidth, $thumbHeight, null, null, true);
 						break;
 
-					// Case for self::CROP_RESIZE
-					case 5:
+					// Crop-resize
+					case self::CROP_RESIZE:
 						$thumb = $this->cropResize($thumbWidth, $thumbHeight, true);
 						break;
 


### PR DESCRIPTION
Pull Request for Issue -
This is https://github.com/joomla/joomla-cms/pull/14402 adapted for Joomla Framework, however without changing `self` to `static` keyword as the first one must be used in methods when declaring defualt values and I'm not sure mixing these two looks good.

### Summary of Changes
Using constants for crop types

### Testing Instructions
none

### Documentation Changes Required
none