### PR TITLE
[1.x] Don't include development related files in distribution package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ Tests/ export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 phpunit.xml.dist export-ignore
+ruleset.xml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
+.github/ export-ignore
+Tests/ export-ignore
+.drone.jsonnet export-ignore
+.drone.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.gitmodules export-ignore
-.travis/ export-ignore
-.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/README.md
+++ b/README.md
@@ -205,3 +205,9 @@ Alternatively, you can simply run the following from the command line:
 ```sh
 composer require joomla/image "~1.0"
 ```
+
+If you want to include the test sources, use
+
+```sh
+composer require --prefer-source joomla/image "~1.0"
+```


### PR DESCRIPTION
### Summary of Changes

* `.gitattributes` is updated to reflect changes
* development related files and directories excluded from distribution packages

### Testing Instructions

* Code review
* The files and directories listed in `.gitattributes` are not included in the zip package

### Documentation Changes Required

`README.md` is changed accordingly.
