### PR TITLE
Update Joomla\Image to compatibility with Php 8.0

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -589,7 +589,8 @@ class Image implements LoggerAwareInterface
 	public function isLoaded()
 	{
 		// Make sure the resource handle is valid.
-		if (!\is_resource($this->handle) || (get_resource_type($this->handle) != 'gd'))
+		if ((!\is_resource($this->handle) || get_resource_type($this->handle) !== 'gd') 
+			&&  (!is_object($this->handle) && !($this->handle instanceof \GDImage)))
 		{
 			return false;
 		}
@@ -653,7 +654,7 @@ class Image implements LoggerAwareInterface
 				// Attempt to create the image handle.
 				$handle = imagecreatefromgif($path);
 
-				if (!\is_resource($handle))
+				if (!\is_resource($handle) && (!is_object($handle) && !($handle instanceOf \GdImage)))
 				{
 					// @codeCoverageIgnoreStart
 					throw new \RuntimeException('Unable to process GIF image.');
@@ -680,7 +681,7 @@ class Image implements LoggerAwareInterface
 				// Attempt to create the image handle.
 				$handle = imagecreatefromjpeg($path);
 
-				if (!\is_resource($handle))
+				if (!\is_resource($handle) && (!is_object($handle) && !($handle instanceOf \GdImage)))
 				{
 					// @codeCoverageIgnoreStart
 					throw new \RuntimeException('Unable to process JPG image.');
@@ -707,7 +708,7 @@ class Image implements LoggerAwareInterface
 				// Attempt to create the image handle.
 				$handle = imagecreatefrompng($path);
 
-				if (!\is_resource($handle))
+				if (!\is_resource($handle) && (!is_object($handle) && !($handle instanceOf \GdImage)))
 				{
 					// @codeCoverageIgnoreStart
 					throw new \RuntimeException('Unable to process PNG image.');


### PR DESCRIPTION
### Summary of Changes

Changes the checks for the Php 8.0 compatibility after the calls of imagecreatefromgif, imagecreatefromjpeg and imagecreatefrompng when the image is loaded because it doesn't return a ressource in Php 8.0 but an object

See [PHP 8.0: GdImage class objects replace GD image resources](https://php.watch/versions/8.0/gdimage) for further information.

### Testing Instructions

### Documentation Changes Required

No.
